### PR TITLE
fix to stat file being rendered by image slider component

### DIFF
--- a/frontend/apps/tekmonks/components/image-slider/image-slider.mjs
+++ b/frontend/apps/tekmonks/components/image-slider/image-slider.mjs
@@ -17,6 +17,7 @@ async function elementConnected(element) {
 async function elementRendered(element) {
 	let imagesPath = element.getAttribute("path");
 	let result = await(await fetch(`${APP_CONSTANTS.API_CMS_DIR_CONTENTS}?q=${imagesPath}`)).json();
+	const filteredFiles = result.files.filter(file => !file.includes("_____________xbin__________ignore_stats")); result = {...result,files: filteredFiles};
 	
 	if (!result.result) return; 
 


### PR DESCRIPTION
@TekMonksGitHub 

Currently, the image-slider is also rendering the Xbin's stat file which only displays a blank slide. This pull request consist of the solution and update to image-slider to ignore the stat file that are being generated by XBin and only display slide with the actual image. 